### PR TITLE
fix pvWidth=0 problem in draw.funcEnrich.cluster

### DIFF
--- a/R/pipeline_functions.R
+++ b/R/pipeline_functions.R
@@ -5661,6 +5661,9 @@ draw.funcEnrich.cluster <- function(funcEnrich_res=NULL,top_number=30,
       mr <- 180/(geneWidth1+pvWidth1+gsWidth1)
       geneWidth1 <- round(geneWidth1*mr)
       pvWidth1 <- round(pvWidth1*mr)
+      if(pvWidth1 < 1){
+        pvWidth1 <- 1
+      }
       gsWidth1 <- ceiling(gsWidth1*mr)
     }
     #####


### PR DESCRIPTION
fix pvWidth=0 problem in draw.funcEnrich.cluster when there are too many genes to plot

When geneWidth1 is very large, mr <- 180/(geneWidth1+pvWidth1+gsWidth1) is less than 0.5, which caused pvWidth1 to be 0. Added a if statement to check that case. 

Please confirm this change. Thanks.