### PR TITLE
Update cgc deployment action path

### DIFF
--- a/.github/workflows/cgc.yml
+++ b/.github/workflows/cgc.yml
@@ -21,7 +21,7 @@ jobs:
           cat cgc/netbid.cwl
       - id: cgcdeploy
         if: ${{ !env.ACT }}
-        uses: jordan-rash/cgc-go@v0.1.4
+        uses: stjudecloud/cgc-go@v0.1.4
         with:
           file_location: cgc/netbid.cwl
           shortid: stjude/netbid/netbid


### PR DESCRIPTION
The CGC deployment action moved from Jordan's namespace to the stjudecloud namespace. This updates the path in the github actions workflow.